### PR TITLE
Update slurp_all_MODS_to_solr.xslt

### DIFF
--- a/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -59,7 +59,7 @@
     <xsl:variable name="this_prefix">
       <xsl:value-of select="concat($prefix, local-name(), '_')"/>
       <xsl:if test="@type">
-        <xsl:value-of select="@type"/>
+        <xsl:value-of select="translate(@type,' ','_')"/>
         <xsl:text>_</xsl:text>
       </xsl:if>
     </xsl:variable>


### PR DESCRIPTION
Where a tag has a @type attribute, and the attribute value has a space in it, the fields get named e.g. “mods_accessCondition_use and reproduction_ms”.  Though you can still search on these fields, they won’t display through the parts of the Islandora interface that show the Solr data. Change replaces spaces with "_" in field names.
